### PR TITLE
sync icon displays properly with db request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,4 +69,5 @@ Note Taking Functionality:
 
 ### Bugs / Tickets to Do
 - [ ] There's a version error mismatch when editing note title and note content back and forth. This occurs when you put a debounce on renaming -> Since the title may have a discrepancy with the note content.
-- [ ] The syncing icon has nothing to do with interaction with the db. It's simply called whenever setUserData is called. Would be worthwhile to implement such that it displays and waits for a 200 response from the server.
+- [X] <del>The syncing icon has nothing to do with interaction with the db. It's simply called whenever setUserData is called. Would be worthwhile to implement such that it displays and waits for a 200 response from the server.</del>
+    - Resolved. The syncing icon now depends on the request instead (see App.jsx syncUserData() for more details).

--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ Note Taking Functionality:
 - [ ] There's a version error mismatch when editing note title and note content back and forth. This occurs when you put a debounce on renaming -> Since the title may have a discrepancy with the note content.
 - [X] <del>The syncing icon has nothing to do with interaction with the db. It's simply called whenever setUserData is called. Would be worthwhile to implement such that it displays and waits for a 200 response from the server.</del>
     - Resolved. The syncing icon now depends on the request instead (see App.jsx syncUserData() for more details).
+- [ ] Add error handling if syncing fails. Display a failed sync message.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Note Taking Functionality:
 - [X] Add "last edited" and "date created" fields.
 - [X] Implement proper debounce for <del>note update</del>, renaming, <del>add</del>, <del>delete</del> to not overwhelm the database.
     - See backlog list as to why debounce was not implemented for renaming. We'll skip it for now and maybe re-visit it later.
-- [X] Show a (naiive) "saving" icon while the data is being uploaded to the db.
+- [X] Show a "syncing" icon while data is being synced to the database.
 
 ### Release v0.3 Goals: Integration of API's
 - [ ] Decklist creation

--- a/client/src/views/NotesPage.jsx
+++ b/client/src/views/NotesPage.jsx
@@ -13,7 +13,7 @@ import {debounce} from 'lodash';
 import SyncingIcon from "../components/SyncingIcon.jsx";
 
 function NotesPage() {
-  const [userData, setUserData] = useOutletContext();
+  const [userData, setUserData, syncing] = useOutletContext();
   const [isVisible, setIsVisible] = useState({
     notebooks: true,
     notes: false,
@@ -30,15 +30,6 @@ function NotesPage() {
   const [renamingNoteId, setRenamingNoteId] = useState(null);
   const [renameValue, setRenameValue] = useState("");
   const [isBtnDisabled, setIsBtnDisabled] = useState(false); // Whether or not add btn is enabled. This is so that user can't spam add the add btn and overload db.
-  const [syncing, setSyncing] = useState(false); // Change this to true whenever data is syncing to the database.
-
-  // Function to handle displaying syncing
-  const handleSyncingMsg = () => {
-    setSyncing(true);
-    setTimeout(() => {
-      setSyncing(false);
-    }, 2000) // No longer syncing after 2 second.
-  }
 
   // Current notebook = selected one.
   const currentNotebook = userData.find(
@@ -171,7 +162,6 @@ function NotesPage() {
       );
       setRenamingNotebookId(null);
       setRenameValue("");
-      handleSyncingMsg();
       return;
     } else if (renamingNoteId) {
       setUserData(
@@ -186,7 +176,6 @@ function NotesPage() {
       );
       setRenamingNoteId(null);
       setRenameValue("");
-      handleSyncingMsg();
     }
   };
 
@@ -199,7 +188,6 @@ function NotesPage() {
     };
     setUserData([...userData, newNotebook]);
     setTimeout(() => setIsBtnDisabled(false), 1000); // Change btn back to enabled after 1 second.
-    handleSyncingMsg();
   };
 
   const handleCreateNote = () => {
@@ -220,7 +208,6 @@ function NotesPage() {
       );
       // Change the btn state back to enabled after 1 second.
       setTimeout(() => setIsBtnDisabled(false), 1000);
-      handleSyncingMsg();
     }
 
   };
@@ -248,11 +235,9 @@ function NotesPage() {
           : notebook
       )
     );
-    handleSyncingMsg()
   };
 
   const handleNoteUpdate = debounce((noteId, updatedContent) => {
-    handleSyncingMsg(); // displays 'syncing' message.
     const now = new Date();
     const formattedDate = now.toISOString().split("T")[0]; // yyyy-mm-dd
     const formattedTime = now.toLocaleTimeString("en-US", { hour12: true, hour:'numeric', minute: 'numeric' }); // Show in 12hr time. Hide the seconds.


### PR DESCRIPTION
Previously the sync icon showed up whenever you _called_ setUserData. Regardless of whether or not the db gave you a 200 ok.

Now the sync icon shows up ONLY if the db gives you a 200 ok. This is to ensure what the user sees is actually accurate to the status of the db.